### PR TITLE
Agent Contexts

### DIFF
--- a/objective_agents/__init__.py
+++ b/objective_agents/__init__.py
@@ -1,5 +1,6 @@
-from objective_agents._base._agent import Agent, system_message
+from objective_agents._base._agent import Agent
 from objective_agents._base._params import Param, ParamInfo
 from objective_agents._base._tool import tool
+from objective_agents._base._context import computed_context, ContextRef, ContextItem
 
-__all__ = ["Agent", "system_message", "Param", "ParamInfo", "tool"]
+__all__ = ["Agent", "Param", "ParamInfo", "tool", "computed_context", "ContextRef", "ContextItem"]

--- a/objective_agents/__init__.py
+++ b/objective_agents/__init__.py
@@ -1,5 +1,5 @@
-from objective_agents._base._agent import BaseAgent, system_message
+from objective_agents._base._agent import Agent, system_message
 from objective_agents._base._params import Param, ParamInfo
 from objective_agents._base._tool import tool
 
-__all__ = ["BaseAgent", "system_message", "Param", "ParamInfo", "tool"]
+__all__ = ["Agent", "system_message", "Param", "ParamInfo", "tool"]

--- a/objective_agents/_base/_agent.py
+++ b/objective_agents/_base/_agent.py
@@ -2,7 +2,6 @@ import inspect
 import json
 import openai
 from typing import Callable
-from collections import defaultdict
 
 from objective_agents.logging import get_logger
 from objective_agents._base._tool import _ToolDefinition
@@ -29,27 +28,7 @@ async def _safe_run(fn, *args, **kwargs):
     return result
 
 
-def system_message(fn):
-    fn._is_system_message = True
-    return fn
-
-
-def model_params(fn):
-    fn._is_model_params = True
-    return fn
-
-
-def prechat(fn):
-    fn.is_prechat = True
-    return fn
-
-
-def postchat(fn):
-    fn.is_postchat = True
-    return fn
-
-
-class BaseAgent:
+class Agent:
     """
     Base agent class to be extended in order to define a new Agent
 
@@ -74,7 +53,6 @@ class BaseAgent:
     """
 
     _tools: dict[str, _ToolDefinition] = {}
-    _tool_defaults = defaultdict(dict)
 
     def __init__(self, model: str, api_key: str, emitter: Callable[[AiUpdate], None] = None):
         self.client: openai.AsyncOpenAI = openai.AsyncOpenAI(api_key=api_key)
@@ -84,6 +62,7 @@ class BaseAgent:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+        cls._tools = {}
 
         for name, attr in cls.__dict__.items():
             if hasattr(attr, "__tool_def__"):

--- a/objective_agents/_base/_agent.py
+++ b/objective_agents/_base/_agent.py
@@ -6,7 +6,7 @@ from typing import Callable, Any, TypeVar, ClassVar
 from objective_agents.logging import get_logger
 from objective_agents._base._tool import _ToolDefinition
 from objective_agents._base._context import ContextItem
-from objective_agents._base._dynamic_init import AgentMeta
+from objective_agents._base._metaclasses import AgentMeta
 from objective_agents.updates import AiUpdate, Status, EmitUpdate, ToolUpdate
 
 logger = get_logger(__name__)
@@ -31,11 +31,6 @@ class Agent(metaclass=AgentMeta):
     Agent defintion requires the use of special function decorators in order to define the
         behavior of the agent.
 
-        - @system_message: A mandatory function defining the system message. This is dynamic,
-            and will be called on each iteration of `chat`.
-        - @prechat: A function that will preprocess the user's message before sending it through
-            the pipeline
-        - @postchat: A function that will process the ai_message before returning it
         - @tool: Declares a method as a tool, allowing the agent to use it
 
     Agents also have default arguements that can be declared on initiation

--- a/objective_agents/_base/_agent.py
+++ b/objective_agents/_base/_agent.py
@@ -107,22 +107,6 @@ class Agent(metaclass=AgentMeta):
             tool_defs.append(tool_def.to_openai(self.context))
         return tool_defs
 
-    @property
-    def _prechat_func(self) -> Callable | None:
-        for attr in dir(self.__class__):
-            fn = getattr(self.__class__, attr)
-            if hasattr(fn, "_is_prechat"):
-                return fn
-        return None
-
-    @property
-    def _postchat_func(self) -> Callable | None:
-        for attr in dir(self.__class__):
-            fn = getattr(self.__class__, attr)
-            if hasattr(fn, "_is_postchat"):
-                return fn
-        return None
-
     async def infer(self, user_message: str) -> str:
         # Generate and insert the new system message
         self.context.add_user_message(user_message)
@@ -189,8 +173,7 @@ class Agent(metaclass=AgentMeta):
 
         # Parse and finalize the Ai Response
         ai_message = response.output_text
-        if self._postchat_func:
-            ai_message = await _safe_run(self._postchat_func, self, ai_message)
+
         self.context._messages.append({"role": "assistant", "content": ai_message})
 
         if self.emitter:

--- a/objective_agents/_base/_agent.py
+++ b/objective_agents/_base/_agent.py
@@ -5,7 +5,7 @@ from typing import Callable, Any, TypeVar, ClassVar
 
 from objective_agents.logging import get_logger
 from objective_agents._base._tool import _ToolDefinition
-from objective_agents._base._context import ContextItem, _AgentContext
+from objective_agents._base._context import ContextItem
 from objective_agents._base._metaclasses import AgentMeta
 from objective_agents.updates import AiUpdate, Status, EmitUpdate, ToolUpdate
 
@@ -47,7 +47,6 @@ class Agent(metaclass=AgentMeta):
     __context_attrs__: ClassVar[dict[str, tuple[TypeVar, ContextItem]]]
     __system_message__: ClassVar[str]
     __input_template__: ClassVar[str] = None
-    #    context: ClassVar[_AgentContext] = None
 
     # Base Attributes
     model: str
@@ -100,8 +99,7 @@ class Agent(metaclass=AgentMeta):
     async def _build_tool_defs(self) -> list[dict]:
         tool_defs = []
         # iterate through registered tools
-        for name, tool_def in self.__tool_defs__.items():
-            fn = getattr(self.__class__, name)
+        for tool_def in self.__tool_defs__.values():
             # Check if any of the tool params use a ContextRef
             # convert to openai schema
             tool_defs.append(tool_def.to_openai(self.context))

--- a/objective_agents/_base/_agent.py
+++ b/objective_agents/_base/_agent.py
@@ -107,9 +107,19 @@ class Agent(metaclass=AgentMeta):
             tool_defs.append(tool_def.to_openai(self.context))
         return tool_defs
 
-    async def infer(self, user_message: str) -> str:
+    async def run(self, input_: str) -> str:
+        """
+        Run the agent with any given input
+
+        Parameters:
+            input_(str): The user input for the agent to process
+
+        Returns:
+            str: The output of the agent
+        """
+
         # Generate and insert the new system message
-        self.context.add_user_message(user_message)
+        self.context.add_user_message(input_)
 
         # Create the tool list
         tool_defs = await self._build_tool_defs()

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -71,7 +71,16 @@ class _AgentContext:
     def add_message(self, role, content):
         self._messages.append({"role": role, "content": content})
 
-    def get(self, name):
+    def get(self, name: str) -> Any:
+        """
+        Retrieves an item from the context.
+
+        Parameters:
+            name(str): The name of the item
+        
+        Returns:
+            Any: The item. If it is a computed context item, then it is computed upon retrieval.
+        """
         try:
             return self.as_dict()[name]
         except KeyError:

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -44,6 +44,7 @@ class _AgentContext:
     """
 
     instructions: str
+    input_template: str = None
     _messages: list = field(default_factory=list)
 
     def as_dict(self):
@@ -68,8 +69,14 @@ class _AgentContext:
         messages.insert(0, {"role": "system", "content": self.system_message})
         return messages
 
-    def add_message(self, role, content):
-        self._messages.append({"role": role, "content": content})
+    def add_user_message(self, message: str):
+        if self.input_template:
+            data = self.as_dict()
+            data["user_message"] = message
+            content = self.input_template.format(**data)
+        else:
+            content = message
+        self._messages.append({"role": "user", "content": content})
 
     def get(self, name: str) -> Any:
         """

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -77,7 +77,7 @@ class _AgentContext:
 
         Parameters:
             name(str): The name of the item
-        
+
         Returns:
             Any: The item. If it is a computed context item, then it is computed upon retrieval.
         """

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -28,6 +28,10 @@ class ContextItem:
     default: Any = None
     default_factory: Callable = None
 
+    def __post_init__(self):
+        if not (self.default or self.default_factory):
+            raise AttributeError("default or default_factory must be given")
+
     def get_default_value(self):
         if self.default_factory:
             return self.default_factory()

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Type, Self
 from dataclasses import dataclass, make_dataclass, field, asdict
 
-from objective_agents._base._exceptions import InvalidContextRef
+from objective_agents._base._exceptions import InvalidContextRefNotFoundInContext
 
 
 @dataclass
@@ -47,7 +47,7 @@ class _AgentContext:
         try:
             return getattr(self, name)
         except AttributeError:
-            raise InvalidContextRef(name)
+            raise InvalidContextRefNotFoundInContext(name)
 
     @classmethod
     def make_ctx_class(cls, name: str, ctx_map: dict[str, tuple[Type[Any], Any]]) -> Type[Self]:

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -16,9 +16,12 @@ class ContextItem:
             return self.default
 
 
-def computed_context(func: callable):
-    func._is_context = True
-    return func
+class computed_context(property):
+    def __init__(self, fget):
+        # initialize the property
+        super().__init__(fget)
+        # mark it as a context‐provider
+        self._is_context = True
 
 
 @dataclass(repr=True)

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -1,0 +1,70 @@
+from typing import Any, Callable
+from dataclasses import dataclass
+
+
+@dataclass
+class ContextItem:
+    default: Any = None
+    default_factory: Callable = None
+
+    def get_default_value(self):
+        if self.default_factory:
+            return self.default_factory()
+        else:
+            return self.default
+
+
+def computed_context(func: callable):
+    func._is_context = True
+    return func
+
+
+class AgentContext:
+    def __init__(self, instructions):
+        self.messages = [{"role": "system", "content": instructions}]
+        self._contexts: dict[str, Any] = {}
+
+    def __getattr__(self, name):
+        if name in self._contexts:
+            return self._contexts[name]
+        raise AttributeError(f"{self.__class__.__name__!r} context has no item {name!r}")
+
+    def __setattr__(self, name, value):
+        # internal attrs go in __dict__; everything else into _data
+        if name in ("contexts", "messages", "_contexts"):
+            object.__setattr__(self, name, value)
+        else:
+            # get the real _data dict without recursion
+            object.__getattribute__(self, "_contexts")[name] = value
+
+    @property
+    def system_message(self):
+        if self.messages:
+            return self.messages[0]
+
+    @system_message.setter
+    def system_message(self, value):
+        if self.messages:
+            self.messages[0] = value
+
+    def add(self, name: str, value: Any):
+        self._contexts[name] = value
+
+
+class ContextRef:
+    """
+    A placeholder pointing at some attribute or method
+    on the agent’s context, to be resolved at schema-build time.
+    """
+
+    def __init__(self, path: str):
+        self.path = path  # dot-notation into agent.context
+
+    def resolve(self, context: AgentContext) -> Any:
+        val = context
+        for part in self.path.split("."):
+            val = getattr(val, part)
+            # if it’s wrapped in our Context helper, drill into .value
+            if hasattr(val, "value"):
+                val = val.value
+        return val() if callable(val) else val

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -30,8 +30,7 @@ class _AgentContext:
 
     def __post_init__(self):
         # Initialize messages and context store
-        object.__setattr__(self, "messages", [{"role": "system", "content": self.instructions}])
-        object.__setattr__(self, "_contexts", {})
+        self.messages = [{"role": "system", "content": self.instructions}]
 
     @property
     def system_message(self) -> dict:
@@ -48,7 +47,7 @@ class _AgentContext:
 
         Args:
             name: base name for the new class (e.g. 'MyAgent').
-            ctx_map: mapping of field name to (type, default or default_info).
+            ctx_map: mapping of field name to (type, ContextItem).
 
         Returns:
             A new dataclass type 'NameContext'.

--- a/objective_agents/_base/_context.py
+++ b/objective_agents/_base/_context.py
@@ -1,6 +1,8 @@
 from typing import Any, Callable, Type, Self
 from dataclasses import dataclass, make_dataclass, field, asdict
 
+from objective_agents._base._exceptions import InvalidContextRef
+
 
 @dataclass
 class ContextItem:
@@ -40,6 +42,12 @@ class _AgentContext:
 
     def add_message(self, role, content):
         self._messages.append({"role": role, "content": content})
+
+    def get(self, name):
+        try:
+            return getattr(self, name)
+        except AttributeError:
+            raise InvalidContextRef(name)
 
     @classmethod
     def make_ctx_class(cls, name: str, ctx_map: dict[str, tuple[Type[Any], Any]]) -> Type[Self]:

--- a/objective_agents/_base/_exceptions.py
+++ b/objective_agents/_base/_exceptions.py
@@ -19,3 +19,12 @@ class UnexpectedContextItemType(Exception):
             f"Expected: {expected} - Recieved: {recieved}"
         )
         super().__init__(message)
+
+
+class InvalidContextRef(Exception):
+    def __init__(self, name):
+        message = (
+            f"'{name}' not found in context. "
+            "Make sure it is either declared as a `ContextItem` or using `computed_context`"
+        )
+        super().__init__(message)

--- a/objective_agents/_base/_exceptions.py
+++ b/objective_agents/_base/_exceptions.py
@@ -8,7 +8,7 @@ class ToolDeclarationFailed(Exception):
 class SystemMessageNotDeclared(Exception):
     def __init__(self):
         super().__init__(
-            "System message not declared on agent. Agent must be declared with `__system_message__`" # noqa E501
+            "System message not declared on agent. Agent must be declared with `__system_message__`"  # noqa E501
         )
 
 

--- a/objective_agents/_base/_exceptions.py
+++ b/objective_agents/_base/_exceptions.py
@@ -3,3 +3,19 @@ class ToolDeclarationFailed(Exception):
     def __init__(self, tool_name, message):
         message = f"Tool declaration failed for {tool_name}" f"{message}"
         super().__init__(message)
+
+
+class SystemMessageNotDeclared(Exception):
+    def __init__(self):
+        super().__init__(
+            "System message not declared on agent. Agent must be declared with `__system_message__`" # noqa E501
+        )
+
+
+class UnexpectedContextItemType(Exception):
+    def __init__(self, name, expected, recieved):
+        message = (
+            f"Unexpected value provided for `{name}`. "
+            f"Expected: {expected} - Recieved: {recieved}"
+        )
+        super().__init__(message)

--- a/objective_agents/_base/_exceptions.py
+++ b/objective_agents/_base/_exceptions.py
@@ -21,10 +21,19 @@ class UnexpectedContextItemType(Exception):
         super().__init__(message)
 
 
-class InvalidContextRef(Exception):
+class InvalidContextRefNotFoundInContext(Exception):
     def __init__(self, name):
         message = (
             f"'{name}' not found in context. "
             "Make sure it is either declared as a `ContextItem` or using `computed_context`"
+        )
+        super().__init__(message)
+
+
+class InvalidContextRefMismatchTyping(Exception):
+    def __init__(self, ref_path, field_name, recieved_type, expected_type):
+        message = (
+            f"ContextRef('{ref_path}') for {self.__class__.__name__}.{field_name}  "
+            f"is of type {recieved_type}, expected {expected_type}"
         )
         super().__init__(message)

--- a/objective_agents/_base/_metaclasses.py
+++ b/objective_agents/_base/_metaclasses.py
@@ -131,7 +131,7 @@ class AgentMeta(type):
 
         if "__system_message__" not in namespace:
             raise SystemMessageNotDeclared()
-        
+
         cls.__tool_defs__ = mcs._extract_tool_defs(namespace)
 
         cls.__annotations__ = mcs._extract_annotations(bases, namespace)

--- a/objective_agents/_base/_metaclasses.py
+++ b/objective_agents/_base/_metaclasses.py
@@ -2,7 +2,7 @@ import inspect
 from typing import dataclass_transform
 
 from objective_agents._base._exceptions import SystemMessageNotDeclared, UnexpectedContextItemType
-from objective_agents._base._context import AgentContext, ContextItem
+from objective_agents._base._context import _AgentContext, ContextItem
 
 
 @dataclass_transform(field_specifiers=(ContextItem,))
@@ -65,7 +65,9 @@ class AgentMeta(type):
     @staticmethod
     def _build_init(sig):
         def __init__(self, *args, **kwargs):  # type: ignore
-            self.context = AgentContext(self.__system_message__)
+            self.context = _AgentContext.make_ctx_class(
+                name=self.__class__.__name__, ctx_map=self.__context_attrs__
+            )(instructions=self.__system_message__)
 
             for attr_name, (attr_type, attr_default) in self.__context_attrs__.items():
                 if attr_name in kwargs:

--- a/objective_agents/_base/_metaclasses.py
+++ b/objective_agents/_base/_metaclasses.py
@@ -1,0 +1,117 @@
+import inspect
+from typing import dataclass_transform
+
+from objective_agents._base._exceptions import SystemMessageNotDeclared, UnexpectedContextItemType
+from objective_agents._base._context import AgentContext, ContextItem
+
+
+@dataclass_transform(field_specifiers=(ContextItem,))
+class AgentMeta(type):
+    """
+    Metaclass that applies only to Agent subclasses:
+      - Ensures @system_message was declared
+      - Collects @tool methods and ContextItem attributes
+      - Initializes class __tools__ and __context__
+      - Dynamically injects an __init__ signature based on class __annotations__
+    """
+
+    @staticmethod
+    def _extract_tool_defs(namespace):
+        tools = {}
+        for attr_name, attr_value in namespace.items():
+            if hasattr(attr_value, "__tool_def__"):
+                tools[attr_name] = attr_value.__tool_def__
+        return tools
+
+    @staticmethod
+    def _extract_annotations(bases, namespace):
+        annotations = {}
+        for base in reversed(bases):
+            if hasattr(base, "__annotations__"):
+                for name, type_ in base.__annotations__.items():
+                    if not name.startswith("__"):
+                        annotations[name] = type_
+        for name, type_ in namespace.get("__annotations__", {}).items():
+            if not name.startswith("__"):
+                annotations[name] = type_
+        return annotations
+
+    @staticmethod
+    def _extract_context_attrs(annotations, namespace):
+        context_attrs = {}
+        for attr_name, attr_type in annotations.items():
+            default = namespace.get(attr_name, None)
+            if isinstance(default, ContextItem):
+                context_attrs[attr_name] = (attr_type, default)
+        return context_attrs
+
+    @staticmethod
+    def _build_init_signature(cls):
+        params = [inspect.Parameter("self", inspect.Parameter.POSITIONAL_ONLY)]
+        for field_name, field_type in cls.__annotations__.items():
+            if field_name in cls.__context_attrs__:
+                default_val = cls.__context_attrs__[field_name][1].get_default_value()
+            else:
+                default_val = getattr(cls, field_name, inspect._empty)
+            param = inspect.Parameter(
+                field_name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=default_val,
+                annotation=field_type,
+            )
+            params.append(param)
+        return inspect.Signature(params)
+
+    @staticmethod
+    def _build_init(sig):
+        def __init__(self, *args, **kwargs):  # type: ignore
+            self.context = AgentContext(self.__system_message__)
+
+            for attr_name, (attr_type, attr_default) in self.__context_attrs__.items():
+                if attr_name in kwargs:
+                    val = kwargs[attr_name]
+                    if (not isinstance(val, attr_type)) or not (
+                        issubclass(val.__class__, attr_type)
+                    ):
+                        raise UnexpectedContextItemType(
+                            name=attr_name, expected=attr_type, recieved=type(val)
+                        )
+                    self.context.add(attr_name, val)
+                else:
+                    self.context.add(attr_name, attr_default.get_default_value())
+
+            bound = sig.bind(self, *args, **kwargs)
+            for name, val in list(bound.arguments.items())[1:]:  # skip 'self'
+                if name in self.__context_attrs__:
+                    pass
+                setattr(self, name, val)
+
+            self.__post_init__()
+
+        # Attach the signature for IDEs and checkers
+        __init__.__signature__ = sig  # type: ignore
+        return __init__
+
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        # Create the class first (so Agent exists)
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+
+        # Skip generation on the abstract base itself
+        if namespace.get("__abstract_base__", False):
+            return cls
+
+        # 1. Validate system_message decorator
+        if "__system_message__" not in namespace:
+            raise SystemMessageNotDeclared()
+
+        cls.__tool_defs__ = mcs._extract_tool_defs(namespace)
+
+        cls.__annotations__ = mcs._extract_annotations(bases, namespace)
+
+        cls.__context_attrs__ = mcs._extract_context_attrs(cls.__annotations__, namespace)
+
+        sig = mcs._build_init_signature(cls)
+        # 5. Dynamically build __init__ signature
+
+        cls.__init__ = mcs._build_init(sig)
+        return cls

--- a/objective_agents/_base/_metaclasses.py
+++ b/objective_agents/_base/_metaclasses.py
@@ -1,5 +1,6 @@
 import inspect
 from typing import dataclass_transform, TypeVar
+from typeguard import check_type
 
 from objective_agents._base._exceptions import SystemMessageNotDeclared, UnexpectedContextItemType
 from objective_agents._base._context import _AgentContext, ContextItem, computed_context
@@ -106,9 +107,7 @@ class AgentMeta(type):
                     continue
                 if attr_name in kwargs:
                     val = kwargs[attr_name]
-                    if (not isinstance(val, attr_type)) or not (
-                        issubclass(val.__class__, attr_type)
-                    ):
+                    if (not check_type(val, attr_type)):
                         raise UnexpectedContextItemType(
                             name=attr_name, expected=attr_type, recieved=type(val)
                         )

--- a/objective_agents/_base/_metaclasses.py
+++ b/objective_agents/_base/_metaclasses.py
@@ -116,7 +116,11 @@ class AgentMeta(type):
                 else:
                     context_kwargs[attr_name] = attr_default.get_default_value()
 
-            self.context = ContextClass(instructions=self.__system_message__, **context_kwargs)
+            self.context = ContextClass(
+                instructions=self.__system_message__,
+                input_template=self.__input_template__,
+                **context_kwargs,
+            )
 
             bound = sig.bind(self, *args, **kwargs)
             for name, val in list(bound.arguments.items())[1:]:  # skip 'self'

--- a/objective_agents/_base/_params.py
+++ b/objective_agents/_base/_params.py
@@ -23,6 +23,16 @@ class ParamInfo(ContextualMixin):
         description (str | None): A human-readable description of the parameter.
         required (bool): Whether this parameter must be provided by the user.
         default (Any): The default value to use if none is provided.
+        values (list[str]): values to limit the input of this parameter. If used, the
+            agent is forced to use on the the values in the list.
+
+    Context-Ready Attributes:
+        These attributes can be given a `ContextRef` to link them to any context items in
+        the agent.
+
+         - description
+         - default
+         - values
     """
 
     description: MaybeContext[str] = None

--- a/objective_agents/_base/_params.py
+++ b/objective_agents/_base/_params.py
@@ -21,9 +21,14 @@ class ParamInfo:
         required (bool): Whether this parameter must be provided by the user.
         default (Any): The default value to use if none is provided.
     """
+
     description: str = None
     required: bool = False
     default: Any = None
+    values: list[str] = None
+
+    def resolve(self, context):
+        pass
 
 
 class Param:
@@ -113,6 +118,8 @@ class Param:
             properties[name]["type"] = _TYPE_MAP.get(type_, "string")
             if info.description:
                 properties[name]["description"] = info.description
+            if info.values:
+                properties[name]["enum"] = info.values
 
             if info.required:
                 required.append(name)

--- a/objective_agents/_base/_params.py
+++ b/objective_agents/_base/_params.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from collections import defaultdict
 from typing import get_type_hints, Any, List, Dict, Type
 
+from objective_agents._base._resolver import ContextualMixin, MaybeContext
+
 # simple mapping from Python types to JSON Schema/OpenAI types
 _TYPE_MAP: Dict[Type[Any], str] = {
     int: "integer",
@@ -12,7 +14,7 @@ _TYPE_MAP: Dict[Type[Any], str] = {
 
 
 @dataclass
-class ParamInfo:
+class ParamInfo(ContextualMixin):
     """
     Declare metadata for parameters in tool declarations and/or Parameter declarations.
 
@@ -22,13 +24,10 @@ class ParamInfo:
         default (Any): The default value to use if none is provided.
     """
 
-    description: str = None
+    description: MaybeContext[str] = None
     required: bool = False
-    default: Any = None
-    values: list[str] = None
-
-    def resolve(self, context):
-        pass
+    default: MaybeContext[Any] = None
+    values: MaybeContext[list[str]] = None
 
 
 class Param:

--- a/objective_agents/_base/_resolver.py
+++ b/objective_agents/_base/_resolver.py
@@ -17,6 +17,12 @@ MaybeContext = Annotated[T, _CtxMarker()]
 
 @dataclass
 class ContextualMixin:
+    """
+    Class to be extended if any of the properties in the class may use a `ContextRef`. Gives the
+    subclass access to `resolve`, which allows a context to be passed in to backfill any
+    context-ready properties
+    """
+
     def resolve(self, ctx: _AgentContext) -> Self:
         updates: dict[str, Any] = {}
         for f in fields(self):

--- a/objective_agents/_base/_resolver.py
+++ b/objective_agents/_base/_resolver.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, fields, replace
+from typing import Annotated, TypeVar, get_origin, get_args, Any, Self
+
+from typeguard import check_type, TypeCheckError
+
+from objective_agents._base._context import _AgentContext, ContextRef
+from objective_agents._base._exceptions import InvalidContextRefMismatchTyping
+
+
+class _CtxMarker:
+    pass
+
+
+T = TypeVar("T")
+MaybeContext = Annotated[T, _CtxMarker()]
+
+
+@dataclass
+class ContextualMixin:
+    def resolve(self, ctx: _AgentContext) -> Self:
+        updates: dict[str, Any] = {}
+        for f in fields(self):
+            tp = f.type
+            # only look at Annotated[...] with our marker
+            if get_origin(tp) is Annotated and any(
+                isinstance(m, _CtxMarker) for m in get_args(tp)[1:]
+            ):
+
+                raw = getattr(self, f.name)
+                if isinstance(raw, ContextRef):
+                    value = ctx.get(raw.path)
+                    # expected type is the first Annotated arg
+                    expected_type = get_args(tp)[0]
+                    try:
+                        check_type(value, expected_type)
+                    except TypeCheckError:
+                        raise InvalidContextRefMismatchTyping(
+                            ref_path=raw.path,
+                            field_name=f.name,
+                            recieved_type=type(value),
+                            expected_type=expected_type,
+                        )
+                    updates[f.name] = value
+                    # return a new instance with those fields replaced
+        return replace(self, **updates)

--- a/objective_agents/_base/_tool.py
+++ b/objective_agents/_base/_tool.py
@@ -52,14 +52,17 @@ class _ToolDefinition:
             type_, default = attr
 
             if issubclass(type_, Param):
-                params[name] = type_.to_openai()
+                params[name] = type_.to_openai(context)
             else:
                 params[name] = {"type": _TYPE_MAP.get(type_, "string")}
             if isinstance(default, ParamInfo):
-                if default.description:
-                    params[name]["description"] = default.description
-                if default.required:
+                resolved_default = default.resolve(context)
+                if resolved_default.description:
+                    params[name]["description"] = resolved_default.description
+                if resolved_default.required:
                     required.append(name)
+                if resolved_default.values:
+                    params[name]["enum"] = resolved_default.values
 
         return {
             "type": "function",

--- a/objective_agents/_base/_tool.py
+++ b/objective_agents/_base/_tool.py
@@ -3,7 +3,7 @@ from typing import Callable, Any, TypeVar, get_type_hints
 from collections import defaultdict
 
 from objective_agents._base._params import Param, ParamInfo, _TYPE_MAP
-from objective_agents._base._context import AgentContext, ContextRef
+from objective_agents._base._context import _AgentContext, ContextRef
 from objective_agents._base._exceptions import ToolDeclarationFailed
 
 
@@ -40,7 +40,7 @@ class _ToolDefinition:
         self.condition = condition
         self.context_links = context_links
 
-    def to_openai(self, context: AgentContext) -> dict:
+    def to_openai(self, context: _AgentContext) -> dict:
         """
         Converts the definition to an "openai-ready" dictionary
 

--- a/objective_agents/_base/_tool.py
+++ b/objective_agents/_base/_tool.py
@@ -3,7 +3,7 @@ from typing import Callable, Any, TypeVar, get_type_hints
 from collections import defaultdict
 
 from objective_agents._base._params import Param, ParamInfo, _TYPE_MAP
-from objective_agents._base._context import _AgentContext, ContextRef
+from objective_agents._base._context import _AgentContext
 from objective_agents._base._exceptions import ToolDeclarationFailed
 
 
@@ -32,13 +32,11 @@ class _ToolDefinition:
         description: str,
         parameters: dict[str, tuple[TypeVar, ParamInfo]],
         condition: Callable[[Any], bool] = None,
-        context_links: list[tuple[str, str]] = None,
     ):
         self.name: str = name
         self.description: str = description
         self.parameters: dict[str, tuple[TypeVar, ParamInfo]] = parameters
         self.condition = condition
-        self.context_links = context_links
 
     def to_openai(self, context: _AgentContext) -> dict:
         """

--- a/objective_agents/_base/_tool.py
+++ b/objective_agents/_base/_tool.py
@@ -3,6 +3,7 @@ from typing import Callable, Any, TypeVar, get_type_hints
 from collections import defaultdict
 
 from objective_agents._base._params import Param, ParamInfo, _TYPE_MAP
+from objective_agents._base._context import AgentContext, ContextRef
 from objective_agents._base._exceptions import ToolDeclarationFailed
 
 
@@ -31,13 +32,15 @@ class _ToolDefinition:
         description: str,
         parameters: dict[str, tuple[TypeVar, ParamInfo]],
         condition: Callable[[Any], bool] = None,
+        context_links: list[tuple[str, str]] = None,
     ):
         self.name: str = name
         self.description: str = description
         self.parameters: dict[str, tuple[TypeVar, ParamInfo]] = parameters
         self.condition = condition
+        self.context_links = context_links
 
-    def to_openai(self) -> dict:
+    def to_openai(self, context: AgentContext) -> dict:
         """
         Converts the definition to an "openai-ready" dictionary
 

--- a/tests/_base/test_agent.py
+++ b/tests/_base/test_agent.py
@@ -1,0 +1,99 @@
+import pytest
+import asyncio
+
+from objective_agents._base._agent import Agent
+from objective_agents._base._context import ContextItem, _AgentContext
+from objective_agents._base._tool import tool, _ToolDefinition
+from objective_agents._base._exceptions import SystemMessageNotDeclared
+
+
+def test_agent_class_declaration_raises_no_system_message():
+    with pytest.raises(SystemMessageNotDeclared) as e:
+
+        class TestAgent(Agent):
+            pass
+
+    assert "SystemMessageNotDeclared" in str(e)
+
+
+def test_agent_class_declaration_no_context_or_tools():
+    class TestAgent(Agent):
+        __system_message__ = "This is a test"
+
+    assert not TestAgent.__context_attrs__
+    assert not TestAgent.__tool_defs__
+
+
+def test_agent_class_declaration_context():
+    class TestAgent(Agent):
+        __system_message__ = "This is a test"
+
+        item: str = ContextItem(default="test")
+
+    assert "item" in TestAgent.__context_attrs__
+    assert TestAgent.__context_attrs__["item"][0] == str
+    assert isinstance(TestAgent.__context_attrs__["item"][1], ContextItem)
+
+
+def test_agent_class_declaration_tool():
+    class TestAgent(Agent):
+        __system_message__ = "This is a test"
+
+        @tool("testing in agent")
+        def test(self) -> str:
+            pass
+
+    assert "test" in TestAgent.__tool_defs__
+    assert isinstance(TestAgent.__tool_defs__["test"], _ToolDefinition)
+    assert TestAgent.__tool_defs__["test"].description == "testing in agent"
+
+
+def test_agent_creation(mock_agent):
+    assert issubclass(mock_agent.__class__, Agent)
+
+
+def test_agent_context_loaded(mock_agent):
+    assert issubclass(mock_agent.context.__class__, _AgentContext)
+
+
+def test_agent_computed_context_attributes(mock_agent):
+    expected = {
+        "instructions": "This is a mock agent",
+        "input_template": None,
+        "_messages": [],
+        "int_default": 4,
+        "str_default": "test",
+        "int_factory": mock_agent.context.int_factory,
+        "str_factory": mock_agent.context.str_factory,
+        "default_override": "overriden",
+        "random_computed": mock_agent.context.random_computed,
+    }
+
+    for name, value in expected.items():
+        attr_value = getattr(mock_agent.context, name, None)
+        if name == "random_computed":
+            assert attr_value > 1000, (
+                f"Value not set properly for {name}\n" f"Expected > 1000" f"Recieved: {attr_value}"
+            )
+        else:
+            assert attr_value == value, (
+                f"Value not set properly for {name}\n"
+                f"Expected: {value}\n"
+                f"Recieved: {attr_value}"
+            )
+
+
+def test_agent_static_tool_ref(mock_agent):
+    openai_tools = asyncio.run(mock_agent._build_tool_defs())
+    for cur_tool in openai_tools:
+        if cur_tool["name"] == "test_ref":
+            assert cur_tool["parameters"]["properties"]["letter"]["enum"] == ["a", "b", "c"]
+            break
+
+
+def test_agent_dynamic_tool_ref(mock_agent):
+    openai_tools = asyncio.run(mock_agent._build_tool_defs())
+    for cur_tool in openai_tools:
+        if cur_tool["name"] == "test_computed_ref":
+            assert cur_tool["parameters"]["properties"]["letter"]["enum"] == ["a", "b", "c"]
+            break

--- a/tests/_base/test_context.py
+++ b/tests/_base/test_context.py
@@ -1,0 +1,165 @@
+import pytest
+import random
+from dataclasses import is_dataclass
+from deepdiff import DeepDiff
+
+from objective_agents._base._context import (
+    ContextItem,
+    computed_context,
+    _AgentContext,
+    ContextRef,
+)
+from objective_agents._base._exceptions import InvalidContextRefNotFoundInContext
+
+
+def test_context_item_default():
+    item = ContextItem(default=4)
+    assert item.get_default_value() == 4
+
+
+def test_context_item_default_factory():
+    item = ContextItem(default_factory=lambda: 4)
+    assert item.get_default_value() == 4
+
+
+def test_computed_context_flag():
+    @computed_context
+    def test():
+        pass
+
+    assert getattr(
+        test, "_is_context", False
+    ), "computed_context not properly flagging function as context"
+
+
+def test_agent_context_class_construction():
+    context_attrs = {
+        "int_default": (int, ContextItem(default=4)),
+        "str_default": (str, ContextItem(default="test")),
+        "int_factory": (int, ContextItem(default_factory=lambda: random.randint(0, 1000))),
+        "str_factory": (
+            str,
+            ContextItem(default_factory=lambda: f"Random: {random.randint(0, 1000)}"),
+        ),
+    }
+    TestClass = _AgentContext.make_ctx_class("Test", context_attrs)
+
+    assert is_dataclass(TestClass), "Created Context class is not a dataclass"
+
+    assert TestClass.__name__ == "TestContext", (
+        "New context name not being set properly\n"
+        "Expected: TestContext\n"
+        f"Recieved: {TestClass.__name__}"
+    )
+    annots = {"int_default": int, "str_default": str, "int_factory": int, "str_factory": str}
+    assert TestClass.__annotations__ == annots, (
+        "annotations not being set properly\n"
+        f"Expected: {annots}\n"
+        f"Recieved: {TestClass.__annotations__}"
+    )
+    assert "int_factory" in TestClass.__dataclass_fields__
+
+
+def test_agent_context_class_construction_with_computed_context():
+    @computed_context
+    def test():
+        return 5
+
+    context_attrs = {
+        "computed": (computed_context, test),
+    }
+    TestClass = _AgentContext.make_ctx_class("Test", context_attrs)
+
+    assert hasattr(
+        TestClass, "computed"
+    ), "Computed context method failed to be bounded to context"
+
+
+# These tests will use the context created in conftest to make tests simplier
+def test_agent_context_default_values(mock_context):
+    assert (
+        mock_context.int_default == 4
+    ), f"Unexpected value with default: {mock_context.int_default}"
+    assert (
+        mock_context.int_factory < 100
+    ), f"Unexpected_value with factory: {mock_context.int_factory}"
+
+
+def test_agent_context_default_override(mock_context):
+    assert (
+        mock_context.default_override == "overriden"
+    ), "Default value not being overriden when supplied in constructor"
+
+
+def test_agent_context_computed_field(mock_context):
+    assert mock_context.random_computed > 1000, "Computed context not set properly"
+
+
+def test_agent_context_as_dict(mock_context):
+    expected = {
+        "instructions": "This is a mock",
+        "input_template": None,
+        "_messages": [],
+        "int_default": 4,
+        "str_default": "test",
+        "int_factory": 63,
+        "str_factory": "Random: 177",
+        "default_override": "overriden",
+        "random_computed": 5,
+    }
+
+    diff = DeepDiff(expected, expected, ignore_order=True)
+
+    assert not diff, f"Dict export does not match expected: \n {diff.pretty()}"
+
+
+def test_agent_context_add_user_message(mock_context):
+    user_message = "Hello"
+    mock_context.add_user_message(user_message)
+    assert mock_context.messages[-1]["content"] == user_message
+
+
+def test_agent_context_add_user_message_with_template(mock_context):
+    mock_context.input_template = "Template: {user_message}"
+    user_message = "Hello"
+    mock_context.add_user_message(user_message)
+    assert mock_context.messages[-1]["content"] == f"Template: {user_message}"
+
+
+def test_agent_context_get_item(mock_context):
+    assert mock_context.get("int_default") == 4
+
+
+def test_agent_context_get_item_raises_not_found(mock_context):
+    with pytest.raises(InvalidContextRefNotFoundInContext) as e:
+        mock_context.get("not real")
+    assert "InvalidContextRefNotFoundInContext" in str(e)
+
+
+def test_agent_context_system_message(mock_context):
+    mock_context.instructions = "System: {int_default}"
+    assert mock_context.system_message == "System: 4"
+
+
+def test_agent_context_system_message_dynamic(mock_context):
+    mock_context.instructions = "System: {random_computed}"
+    assert mock_context.system_message != mock_context.system_message
+
+
+def test_agent_context_messages_dynamic(mock_context):
+    mock_context.instructions = "System: {random_computed}"
+    first = mock_context.messages[0]["content"]
+    second = mock_context.messages[0]["content"]
+    assert first != second
+
+
+def test_context_ref_resolve(mock_context):
+    ref = ContextRef("int_default")
+    assert ref.resolve(mock_context) == 4
+
+
+def test_context_ref_dynamic(mock_context):
+    ref = ContextRef("random_computed")
+    first = ref.resolve(mock_context)
+    second = ref.resolve(mock_context)
+    assert first != second

--- a/tests/_base/test_context.py
+++ b/tests/_base/test_context.py
@@ -95,6 +95,33 @@ def test_agent_context_computed_field(mock_context):
     assert mock_context.random_computed > 1000, "Computed context not set properly"
 
 
+def test_agent_context_attributes(mock_context):
+    expected = {
+        "instructions": "This is a mock",
+        "input_template": None,
+        "_messages": [],
+        "int_default": 4,
+        "str_default": "test",
+        "int_factory": mock_context.int_factory,
+        "str_factory": mock_context.str_factory,
+        "default_override": "overriden",
+        "random_computed": mock_context.random_computed,
+    }
+
+    for name, value in expected.items():
+        attr_value = getattr(mock_context, name, None)
+        if name == "random_computed":
+            assert attr_value > 1000, (
+                f"Value not set properly for {name}\n" f"Expected > 1000" f"Recieved: {attr_value}"
+            )
+        else:
+            assert attr_value == value, (
+                f"Value not set properly for {name}\n"
+                f"Expected: {value}\n"
+                f"Recieved: {attr_value}"
+            )
+
+
 def test_agent_context_as_dict(mock_context):
     expected = {
         "instructions": "This is a mock",
@@ -102,10 +129,10 @@ def test_agent_context_as_dict(mock_context):
         "_messages": [],
         "int_default": 4,
         "str_default": "test",
-        "int_factory": 63,
-        "str_factory": "Random: 177",
+        "int_factory": mock_context.int_factory,
+        "str_factory": f"Random: {mock_context.str_factory}",
         "default_override": "overriden",
-        "random_computed": 5,
+        "random_computed": mock_context.random_computed,
     }
 
     diff = DeepDiff(expected, expected, ignore_order=True)

--- a/tests/_base/test_tool.py
+++ b/tests/_base/test_tool.py
@@ -3,6 +3,7 @@ from deepdiff import DeepDiff
 
 from objective_agents._base._tool import tool, _ToolDefinition
 from objective_agents._base._params import Param, ParamInfo
+from objective_agents._base._context import ContextRef
 from objective_agents._base._exceptions import ToolDeclarationFailed
 
 
@@ -98,7 +99,7 @@ def test_tool_declaration_with_annotated_param():
     ), "Given ParamInfo not being set in tool def, got: {info}, expected: ParamInfo(description='this is a test)"  # noqa E501
 
 
-def test_tool_openai_export():
+def test_tool_openai_export(mock_context):
     class TestParam(Param):
         param_primitive: int
 
@@ -113,7 +114,7 @@ def test_tool_openai_export():
     ) -> str:
         pass
 
-    openai_tool = test.__tool_def__.to_openai()
+    openai_tool = test.__tool_def__.to_openai(mock_context)
     expected = {
         "type": "function",
         "name": "test",
@@ -153,7 +154,7 @@ def test_tool_openai_export():
     assert not diff, f"OpenAI Export does not match expected: \n {diff.pretty()}"
 
 
-def test_tool_openai_export_multiple_params():
+def test_tool_openai_export_multiple_params(mock_context):
     class TestParamA(Param):
         param_primitive_a: int
 
@@ -167,7 +168,7 @@ def test_tool_openai_export_multiple_params():
     ) -> str:
         pass
 
-    openai_tool = test.__tool_def__.to_openai()
+    openai_tool = test.__tool_def__.to_openai(mock_context)
     expected = {
         "type": "function",
         "name": "test",
@@ -193,3 +194,22 @@ def test_tool_openai_export_multiple_params():
     diff = DeepDiff(openai_tool, expected, ignore_order=True)
 
     assert not diff, f"OpenAI Export does not match expected: \n {diff.pretty()}"
+
+
+def test_tool_openai_export_context_resolve(mock_context):
+    class ResolveParam(Param):
+        field: str = ParamInfo(description=ContextRef("str_default"))
+
+    @tool("Testing context resolve on tool level")
+    def test(param: ResolveParam) -> str:
+        pass
+
+    openai_tool = test.__tool_def__.to_openai(mock_context)
+    export_description = openai_tool["parameters"]["properties"]["param"]["properties"]["field"][
+        "description"
+    ]
+    assert export_description == "test", (
+        "The resolved description did not match that in the mock context\n"
+        f"Expected: {mock_context.str_default}\n"
+        f"Recieved: {export_description}\n"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
 import pytest
 import random
 
-from objective_agents._base._context import _AgentContext, ContextItem, computed_context
+from objective_agents._base._context import (
+    _AgentContext,
+    ContextItem,
+    computed_context,
+    ContextRef,
+)
+from objective_agents._base._tool import tool
+from objective_agents._base._params import ParamInfo
+from objective_agents._base._agent import Agent
 
 
 @pytest.fixture
@@ -25,3 +33,47 @@ def mock_context():
         },
     )
     yield MockContext(instructions="This is a mock", default_override="overriden")
+
+
+@pytest.fixture
+def mock_agent():
+    class MockAgent(Agent):
+        __system_message__ = "This is a mock agent"
+
+        int_default: int = ContextItem(default=4)
+        str_default: str = ContextItem(default="test")
+        int_factory: int = ContextItem(default_factory=lambda: random.randint(0, 100))
+        str_factory: str = ContextItem(
+            default_factory=lambda: f"Random: {random.randint(100, 200)}"
+        )
+        default_override: str = ContextItem(default="testing")
+        test_enum_values: list[str] = ContextItem(default_factory=list)
+
+        @computed_context
+        def random_computed(self):
+            return self.int_default * random.randint(1000, 10000)
+
+        @computed_context
+        def computed_values(self):
+            return ["a", "b", "c"]
+
+        @tool("Testing from mock agent")
+        def test(self) -> str:
+            pass
+
+        @tool("Testing params in tool with ref")
+        def test_ref(self, letter: str = ParamInfo(values=ContextRef("test_enum_values"))) -> str:
+            pass
+
+        @tool("testing ref with computed")
+        def test_computed_ref(
+            self, letter: str = ParamInfo(values=ContextRef("computed_values"))
+        ) -> str:
+            pass
+
+    yield MockAgent(
+        model="mock",
+        api_key="MyKey",
+        default_override="overriden",
+        test_enum_values=["a", "b", "c"],
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,27 @@
 import pytest
 import random
 
-from objective_agents._base._context import _AgentContext, ContextItem
+from objective_agents._base._context import _AgentContext, ContextItem, computed_context
 
 
 @pytest.fixture
 def mock_context():
+    @computed_context
+    def test(self):
+        return random.randint(1000, 10000)
+
     MockContext = _AgentContext.make_ctx_class(
         "Mock",
         ctx_map={
             "int_default": (int, ContextItem(default=4)),
             "str_default": (str, ContextItem(default="test")),
-            "int_factory": (int, ContextItem(default_factory=lambda: random.randint(0, 1000))),
+            "int_factory": (int, ContextItem(default_factory=lambda: random.randint(0, 100))),
             "str_factory": (
                 str,
-                ContextItem(default_factory=lambda: f"Random: {random.randint(0, 1000)}"),
+                ContextItem(default_factory=lambda: f"Random: {random.randint(100, 200)}"),
             ),
+            "random_computed": (computed_context, test),
+            "default_override": (str, ContextItem(default="testing")),
         },
     )
-    yield MockContext(instructions="This is a mock")
+    yield MockContext(instructions="This is a mock", default_override="overriden")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+import random
+
+from objective_agents._base._context import _AgentContext, ContextItem
+
+
+@pytest.fixture
+def mock_context():
+    MockContext = _AgentContext.make_ctx_class(
+        "Mock",
+        ctx_map={
+            "int_default": (int, ContextItem(default=4)),
+            "str_default": (str, ContextItem(default="test")),
+            "int_factory": (int, ContextItem(default_factory=lambda: random.randint(0, 1000))),
+            "str_factory": (
+                str,
+                ContextItem(default_factory=lambda: f"Random: {random.randint(0, 1000)}"),
+            ),
+        },
+    )
+    yield MockContext(instructions="This is a mock")


### PR DESCRIPTION
Added the following features:
 - Agent metaclass to facilitate declareing a new agent subclass. This includes creating __tool_defs__, __context_attrs__ as well as creating a typed __init__ for each new subclass
 - Added `ContextItem` and `computed_context` so users can specify relevant information for their agents. This can be injected in a numerous amount of locations in the agent including the system message, an input template, and in tools using ContextRefs
 - Wired up new agent logic into `run` method to dynamically create system message as well as tool definitions
 - Added more test coverage