### PR TITLE
Feat/new response objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.0.1-a.1 (2025-08-07)
+
+### Bug Fixes
+
+- Ensuring openai package is up-to-date
+  ([`a9653ea`](https://github.com/rmikulec/pyAgentic/commit/a9653eabd5b4fab573855c61add1336e5c11f268))
+
+
 ## v1.0.0 (2025-08-07)
 
 

--- a/pyagentic/_base/_agent.py
+++ b/pyagentic/_base/_agent.py
@@ -1,12 +1,14 @@
 import inspect
 import json
 import openai
-from typing import Callable, Any, TypeVar, ClassVar
+from typing import Callable, Any, TypeVar, ClassVar, Type
 
 from pyagentic.logging import get_logger
 from pyagentic._base._tool import _ToolDefinition
 from pyagentic._base._context import ContextItem
 from pyagentic._base._metaclasses import AgentMeta
+
+from pyagentic.models.response import ToolResponse, AgentResponse
 from pyagentic.updates import AiUpdate, Status, EmitUpdate, ToolUpdate
 
 logger = get_logger(__name__)
@@ -24,7 +26,7 @@ async def _safe_run(fn, *args, **kwargs):
 
 
 class Agent(metaclass=AgentMeta):
-    __abstract_base__ = True
+    __abstract_base__ = ClassVar[True]
     """
     Base agent class to be extended in order to define a new Agent
 
@@ -47,6 +49,8 @@ class Agent(metaclass=AgentMeta):
     __context_attrs__: ClassVar[dict[str, tuple[TypeVar, ContextItem]]]
     __system_message__: ClassVar[str]
     __input_template__: ClassVar[str] = None
+    __response_model__: ClassVar[Type[AgentResponse]] = None
+    __tool_response_models__: ClassVar[dict[str, Type[ToolResponse]]]
 
     # Base Attributes
     model: str
@@ -56,7 +60,7 @@ class Agent(metaclass=AgentMeta):
     def __post_init__(self):
         self.client: openai.AsyncOpenAI = openai.AsyncOpenAI(api_key=self.api_key)
 
-    async def _process_tool_call(self, tool_call) -> bool:
+    async def _process_tool_call(self, tool_call) -> ToolResponse:
         if tool_call.type != "function_call":
             return False
         self.context._messages.append(tool_call)
@@ -94,7 +98,10 @@ class Agent(metaclass=AgentMeta):
         self.context._messages.append(
             {"type": "function_call_output", "call_id": tool_call.call_id, "output": result}
         )
-        return True
+        ToolCalledModel = self.__tool_response_models__[tool_call.name]
+        return ToolCalledModel(
+            raw_kwargs=tool_call.arguments, call_depth=0, output=result, **compiled_args
+        )
 
     async def _build_tool_defs(self) -> list[dict]:
         tool_defs = []
@@ -157,12 +164,13 @@ class Agent(metaclass=AgentMeta):
             self.context._messages.extend(reasoning)
 
         # Dispatch any tool calls
-        made_calls = False
+        tool_responses = []
         for tool_call in tool_calls:
-            made_calls = made_calls or (await self._process_tool_call(tool_call))
+            tool_response = await self._process_tool_call(tool_call)
+            tool_responses.append(tool_response)
 
         # If tools ran, re-invoke LLM for natural reply
-        if made_calls:
+        if tool_responses:
             try:
                 response = await self.client.responses.create(
                     model=self.model,
@@ -187,4 +195,8 @@ class Agent(metaclass=AgentMeta):
         if self.emitter:
             await _safe_run(self.emitter, AiUpdate(status=Status.SUCCEDED, message=ai_message))
 
-        return ai_message
+        return self.__response_model__(
+            response=response,
+            final_output=ai_message,
+            tool_responses=tool_responses,
+        )

--- a/pyagentic/_base/_params.py
+++ b/pyagentic/_base/_params.py
@@ -64,6 +64,8 @@ class Param:
         super().__init_subclass__(**kwargs)
         cls.__attributes__ = {}
         for name, type_ in get_type_hints(cls).items():
+            if name.startswith("__") and name.endswith("__"):
+                continue
             default = cls.__dict__.get(name, None)
             if isinstance(default, ParamInfo):
                 cls.__attributes__[name] = (type_, default)

--- a/pyagentic/models/response.py
+++ b/pyagentic/models/response.py
@@ -1,0 +1,95 @@
+from pydantic import BaseModel, Field, create_model
+from typing import Type, get_origin, get_args, Self, Union
+
+from openai.types.responses import Response
+
+from pyagentic._base._tool import _ToolDefinition
+from pyagentic._base._params import Param
+
+
+PRIMITIVES = (bool, str, int, float, type(None))
+
+
+def is_primitive(cls):
+    return cls in PRIMITIVES
+
+
+def param_to_pydantic(ParamClass: Type[Param]) -> Type[BaseModel]:
+    fields = {}
+
+    for attr_name, (attr_type, attr_info) in ParamClass.__attributes__.items():
+        if get_origin(attr_type) == list:
+            origin_type = get_args(attr_type)[0]
+            if is_primitive(origin_type):
+                fields[attr_name] = (
+                    list[attr_type],
+                    Field(default=attr_info.default, description=attr_info.description),
+                )
+            elif issubclass(origin_type, Param):
+                SubParamModel = param_to_pydantic(origin_type)
+                fields[attr_name] = (
+                    list[SubParamModel],
+                    Field(default=attr_info.default, description=attr_info.description),
+                )
+            else:
+                raise Exception(f"Unsupported type: {attr_type}")
+        elif is_primitive(attr_type):
+            fields[attr_name] = (
+                attr_type,
+                Field(default=attr_info.default, description=attr_info.description),
+            )
+        elif issubclass(attr_type, Param):
+            SubParamModel = param_to_pydantic(attr_type)
+            fields[attr_name] = (
+                SubParamModel,
+                Field(default=attr_info.default, description=attr_info.description),
+            )
+        else:
+            raise Exception(f"Unsupported type: {attr_type}")
+
+    return create_model(f"{ParamClass.__name__}", **fields)
+
+
+class ToolResponse(BaseModel):
+    raw_kwargs: str
+    call_depth: int
+    output: str
+
+    @classmethod
+    def from_tool_def(cls, tool_def: _ToolDefinition) -> Type[Self]:
+        """
+        Creates a subclass of `ToolCalled`, using the Tool Definition to make the kwargs
+            accessible through pydantic
+        """
+        fields = {}
+        for param_name, (param_type, param_info) in tool_def.parameters.items():
+            if get_origin(param_type) == list:
+                pass
+            elif is_primitive(param_type):
+                fields[param_name] = (
+                    param_type,
+                    Field(default=param_info.default, description=param_info.description),
+                )
+            elif issubclass(param_type, Param):
+                fields[param_name] = (
+                    param_to_pydantic(param_type),
+                    Field(default=param_info.default, description=param_info.description),
+                )
+            else:
+                raise Exception(f"Unsupported type: {param_type}")
+
+        return create_model(f"ToolCalled[{tool_def.name}]", __base__=cls, **fields)
+
+
+class AgentResponse(BaseModel):
+    response: Response
+    final_output: str
+
+    @classmethod
+    def from_tool_defs(
+        cls, agent_name: str, tool_response_models: list[Type[ToolResponse]]
+    ) -> Type[Self]:
+        ToolResult = Union[tuple(tool_response_models)]
+        return create_model(
+            f"{agent_name}Response", __base__=cls, tool_responses=(list[ToolResult], ...)
+        )

--- a/pyagentic/models/response.py
+++ b/pyagentic/models/response.py
@@ -77,7 +77,7 @@ class ToolResponse(BaseModel):
     @classmethod
     def from_tool_def(cls, tool_def: _ToolDefinition) -> Type[Self]:
         """
-        Creates a subclass of `ToolCalled`, using the Tool Definition to make the kwargs
+        Creates a subclass of `ToolResponse`, using the Tool Definition to make the kwargs
             accessible through pydantic
         """
         fields = {}
@@ -97,7 +97,7 @@ class ToolResponse(BaseModel):
             else:
                 raise Exception(f"Unsupported type: {param_type}")
 
-        return create_model(f"ToolCalled[{tool_def.name}]", __base__=cls, **fields)
+        return create_model(f"ToolResponse[{tool_def.name}]", __base__=cls, **fields)
 
 
 class AgentResponse(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     "colorlog>=6.9.0",
     "ipykernel>=6.29.5",
-    "openai>=1.93.2",
+    "openai>=1.99.3",
     "typeguard>=4.4.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "colorlog>=6.9.0",
     "ipykernel>=6.29.5",
     "openai>=1.99.3",
+    "pydantic>=2.11.7",
     "typeguard>=4.4.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyagentic-core"
-version = "1.0.0"
+version = "1.0.1-a.1"
 description = "Build LLM Agents in a Pythonic way"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.99.1"
+version = "1.99.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -599,9 +599,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/30/f0fb7907a77e733bb801c7bdcde903500b31215141cdb261f04421e6fbec/openai-1.99.1.tar.gz", hash = "sha256:2c9d8e498c298f51bb94bcac724257a3a6cac6139ccdfc1186c6708f7a93120f", size = 497075, upload-time = "2025-08-05T19:42:36.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d3/c372420c8ca1c60e785fd8c19e536cea8f16b0cfdcdad6458e1d8884f2ea/openai-1.99.3.tar.gz", hash = "sha256:1a0e2910e4545d828c14218f2ac3276827c94a043f5353e43b9413b38b497897", size = 504932, upload-time = "2025-08-07T20:35:15.893Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/15/9c85154ffd283abfc43309ff3aaa63c3fd02f7767ee684e73670f6c5ade2/openai-1.99.1-py3-none-any.whl", hash = "sha256:8eeccc69e0ece1357b51ca0d9fb21324afee09b20c3e5b547d02445ca18a4e03", size = 767827, upload-time = "2025-08-05T19:42:34.192Z" },
+    { url = "https://files.pythonhosted.org/packages/92/bc/e52f49940b4e320629da7db09c90a2407a48c612cff397b4b41b7e58cdf9/openai-1.99.3-py3-none-any.whl", hash = "sha256:c786a03f6cddadb5ee42c6d749aa4f6134fe14fdd7d69a667e5e7ce7fd29a719", size = 785776, upload-time = "2025-08-07T20:35:13.653Z" },
 ]
 
 [[package]]
@@ -717,7 +717,7 @@ wheels = [
 
 [[package]]
 name = "pyagentic-core"
-version = "1.0.0"
+version = "1.0.1a1"
 source = { virtual = "." }
 dependencies = [
     { name = "colorlog" },
@@ -742,7 +742,7 @@ dev = [
 requires-dist = [
     { name = "colorlog", specifier = ">=6.9.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
-    { name = "openai", specifier = ">=1.93.2" },
+    { name = "openai", specifier = ">=1.99.3" },
     { name = "typeguard", specifier = ">=4.4.4" },
 ]
 


### PR DESCRIPTION
Changed the response to `Agent.run` from a string to a Agent-specific response model. This response model allows users to see what tools were called as well as a raw response from openai.

This PR sets up for the following:
 - Agent "goal-oriented" run, meaning tools can be called many times until the agent achieves its goal. This PR allows a response that captures all the interworkings of a call like this
 - Auto generated fastapi app. The idea of this would be an FastAPI app could be auto-generated and stood up given an agent. This PR allows that to happen, by created a predetermiend response structure for each agent